### PR TITLE
Automated Svelte compilation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,6 +1,7 @@
 project:
   type: website
   output-dir: docs
+  pre-process: preprocess.ts
   resources:
     - /web-component-tut/public/build/*
     

--- a/preprocess.ts
+++ b/preprocess.ts
@@ -1,0 +1,9 @@
+console.log(
+  "Output directory: " +
+  Deno.env.get("QUARTO_PROJECT_OUTPUT_DIR"));
+
+const in_files = Deno.env.get("QUARTO_PROJECT_INPUT_FILES")
+
+console.log(in_files.split("\n").length + " files to render:");
+
+console.log(in_files)


### PR DESCRIPTION
The goal of this is to get Svelte compilation happening automatically when rendering documents.

The big blocker is that the version of Deno included with Quarto is locked down: you can't install things in it. That means that installing [snel](https://github.com/crewdevio/Snel), the Deno version of Svelte, is impossible unless you refer out to an externally installed version of Deno (and then it becomes debatable whether you should just revert to the original Svelte compiler).

But the automation parts seems doable. I see a few parts to it:

* Identifying the files to be rendered and the output directory ([Quarto project pre-process scripts](https://quarto.org/docs/projects/scripts.html#pre-and-post-render) get this info)
* Identifying references to `.svelte` files in the rendered files
* Compiling those references to `.js` bundles
* Post-render (or possibly during render with a lua filter), swapping the references to `.svelte` to `.js`